### PR TITLE
Fix explicit handling of no compile-time conditional branches

### DIFF
--- a/core/src/lower.rs
+++ b/core/src/lower.rs
@@ -99,9 +99,9 @@ pub(crate) fn lower(analyzed: AnalyzedConditionalQueryAs) -> LoweredConditionalQ
     // TODO: Think about whether we just return earlier in the pipeline and just return the
     // original macro input as a `query_as!` macro.
     if match_expressions.is_empty() {
-        match_expressions.push(parse_quote!(true));
+        match_expressions.push(parse_quote!(()));
         match_arms.push(crate::lower::MatchArm {
-            patterns: vec![parse_quote!(true)],
+            patterns: vec![parse_quote!(())],
             compile_time_bindings: HashMap::new(),
         });
     }


### PR DESCRIPTION
Previously we added a single match expression of `true` when there were no specified conditional branches.  This of course leads to a non-exhaustive pattern match error since there's no corresponding `false` branch.  We should be using unit instead of a boolean here.

Fixes #8.