### PR TITLE
Deprecated `fetch_many` method since it was deprecated in `sqlx` 0.7.4.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Deprecated
+
+- Deprecated `fetch_many` method since it was deprecated in `sqlx` 0.7.4. ([#17](https://github.com/kyrias/sqlx-conditional-queries/pull/17))
+
 
 ## [0.1.3] - 2023-07-12
 

--- a/core/src/codegen.rs
+++ b/core/src/codegen.rs
@@ -95,6 +95,7 @@ fn build_conditional_map(variant_count: usize) -> proc_macro2::TokenStream {
             }
 
             /// See [`sqlx::query::Map::fetch_many`]
+            #[deprecated = "Only the SQLite driver supports multiple statements in one prepared statement and that behavior is deprecated. Use `sqlx::raw_sql()` instead. See https://github.com/launchbadge/sqlx/issues/3108 for discussion."]
             pub fn fetch_many<'e, 'c: 'e, E>(
                 mut self,
                 executor: E,
@@ -110,7 +111,10 @@ fn build_conditional_map(variant_count: usize) -> proc_macro2::TokenStream {
             {
                 match self {
                     #(
-                        Self::#variants(map) => map.fetch_many(executor),
+                        Self::#variants(map) => {
+                            #[allow(deprecated)]
+                            map.fetch_many(executor)
+                        }
                     )*
                 }
             }


### PR DESCRIPTION
Hello.

I use this crate because it is very useful for using `sqlx`. Now that I have updated `sqlx` to `0.7.4`, I get a warning on `conditional_query_as!()`.

```
warning: use of deprecated method `sqlx::query::Map::<'q, DB, F, A>::fetch_many`: Only the SQLite driver supports multiple statements in one prepared statement and that behavior is deprecated. Use `sqlx::raw_sql()` instead.
```

It seems that [`Map::fetch_many()`](https://docs.rs/sqlx/latest/sqlx/query/struct.Map.html#method.fetch_many) was deprecated in `sqlx 0.7.4`.

I am not using this method but I get a warning. Therefore, I would like to modify it so that the warning is only issued when the method is used.

Please let me know if there is something I should do.

Thanks.