### PR TITLE
Fix queries only containing run-time bound parameters

### DIFF
--- a/core/src/lower.rs
+++ b/core/src/lower.rs
@@ -83,6 +83,11 @@ pub(crate) fn lower(analyzed: AnalyzedConditionalQueryAs) -> LoweredConditionalQ
     // keep track of which match expressions belongs to which part of the match arm's expression.
     let mut match_arms = Vec::new();
     for binding in bindings.into_iter().multi_cartesian_product() {
+        // `multi_cartesian_product` returns one empty `Vec` if the iterator was empty.
+        if binding.is_empty() {
+            continue;
+        }
+
         let mut guards = Vec::new();
         let mut bindings = HashMap::new();
         binding.into_iter().for_each(|(g, b)| {

--- a/core/src/snapshots/sqlx_conditional_queries_core__snapshot_tests__only_runtime_bound_parameters@MySql.snap
+++ b/core/src/snapshots/sqlx_conditional_queries_core__snapshot_tests__only_runtime_bound_parameters@MySql.snap
@@ -5,17 +5,15 @@ snapshot_kind: text
 ---
 fn dummy() {
     {
-        enum ConditionalMap<'q, DB: ::sqlx::Database, A, F0, F1> {
+        enum ConditionalMap<'q, DB: ::sqlx::Database, A, F0> {
             Variant0(::sqlx::query::Map<'q, DB, F0, A>),
-            Variant1(::sqlx::query::Map<'q, DB, F1, A>),
         }
-        impl<'q, DB, A, O, F0, F1> ConditionalMap<'q, DB, A, F0, F1>
+        impl<'q, DB, A, O, F0> ConditionalMap<'q, DB, A, F0>
         where
             DB: ::sqlx::Database,
             A: 'q + ::sqlx::IntoArguments<'q, DB> + ::std::marker::Send,
             O: ::std::marker::Unpin + ::std::marker::Send,
             F0: ::std::ops::FnMut(DB::Row) -> ::sqlx::Result<O> + ::std::marker::Send,
-            F1: ::std::ops::FnMut(DB::Row) -> ::sqlx::Result<O> + ::std::marker::Send,
         {
             /// See [`sqlx::query::Map::fetch`]
             pub fn fetch<'e, 'c: 'e, E>(
@@ -28,11 +26,9 @@ fn dummy() {
                 DB: 'e,
                 O: 'e,
                 F0: 'e,
-                F1: 'e,
             {
                 match self {
                     Self::Variant0(map) => map.fetch(executor),
-                    Self::Variant1(map) => map.fetch(executor),
                 }
             }
             /// See [`sqlx::query::Map::fetch_many`]
@@ -50,11 +46,9 @@ fn dummy() {
                 DB: 'e,
                 O: 'e,
                 F0: 'e,
-                F1: 'e,
             {
                 match self {
                     Self::Variant0(map) => #[allow(deprecated)] map.fetch_many(executor),
-                    Self::Variant1(map) => #[allow(deprecated)] map.fetch_many(executor),
                 }
             }
             /// See [`sqlx::query::Map::fetch_all`]
@@ -68,11 +62,9 @@ fn dummy() {
                 DB: 'e,
                 O: 'e,
                 F0: 'e,
-                F1: 'e,
             {
                 match self {
                     Self::Variant0(map) => map.fetch_all(executor).await,
-                    Self::Variant1(map) => map.fetch_all(executor).await,
                 }
             }
             /// See [`sqlx::query::Map::fetch_one`]
@@ -83,11 +75,9 @@ fn dummy() {
                 DB: 'e,
                 O: 'e,
                 F0: 'e,
-                F1: 'e,
             {
                 match self {
                     Self::Variant0(map) => map.fetch_one(executor).await,
-                    Self::Variant1(map) => map.fetch_one(executor).await,
                 }
             }
             /// See [`sqlx::query::Map::fetch_optional`]
@@ -101,26 +91,15 @@ fn dummy() {
                 DB: 'e,
                 O: 'e,
                 F0: 'e,
-                F1: 'e,
             {
                 match self {
                     Self::Variant0(map) => map.fetch_optional(executor).await,
-                    Self::Variant1(map) => map.fetch_optional(executor).await,
                 }
             }
         }
         match ((),) {
-            () => {
-                ConditionalMap::Variant0(
-                    ::sqlx::query_as!(
-                        OutputType,
-                        "\n            SELECT column\n            FROM table\n            WHERE created_at > "
-                        + "?" + "\n        ", created_at
-                    ),
-                )
-            }
             ((),) => {
-                ConditionalMap::Variant1(
+                ConditionalMap::Variant0(
                     ::sqlx::query_as!(
                         OutputType,
                         "\n            SELECT column\n            FROM table\n            WHERE created_at > "

--- a/core/src/snapshots/sqlx_conditional_queries_core__snapshot_tests__only_runtime_bound_parameters@PostgreSql.snap
+++ b/core/src/snapshots/sqlx_conditional_queries_core__snapshot_tests__only_runtime_bound_parameters@PostgreSql.snap
@@ -5,17 +5,15 @@ snapshot_kind: text
 ---
 fn dummy() {
     {
-        enum ConditionalMap<'q, DB: ::sqlx::Database, A, F0, F1> {
+        enum ConditionalMap<'q, DB: ::sqlx::Database, A, F0> {
             Variant0(::sqlx::query::Map<'q, DB, F0, A>),
-            Variant1(::sqlx::query::Map<'q, DB, F1, A>),
         }
-        impl<'q, DB, A, O, F0, F1> ConditionalMap<'q, DB, A, F0, F1>
+        impl<'q, DB, A, O, F0> ConditionalMap<'q, DB, A, F0>
         where
             DB: ::sqlx::Database,
             A: 'q + ::sqlx::IntoArguments<'q, DB> + ::std::marker::Send,
             O: ::std::marker::Unpin + ::std::marker::Send,
             F0: ::std::ops::FnMut(DB::Row) -> ::sqlx::Result<O> + ::std::marker::Send,
-            F1: ::std::ops::FnMut(DB::Row) -> ::sqlx::Result<O> + ::std::marker::Send,
         {
             /// See [`sqlx::query::Map::fetch`]
             pub fn fetch<'e, 'c: 'e, E>(
@@ -28,11 +26,9 @@ fn dummy() {
                 DB: 'e,
                 O: 'e,
                 F0: 'e,
-                F1: 'e,
             {
                 match self {
                     Self::Variant0(map) => map.fetch(executor),
-                    Self::Variant1(map) => map.fetch(executor),
                 }
             }
             /// See [`sqlx::query::Map::fetch_many`]
@@ -50,11 +46,9 @@ fn dummy() {
                 DB: 'e,
                 O: 'e,
                 F0: 'e,
-                F1: 'e,
             {
                 match self {
                     Self::Variant0(map) => #[allow(deprecated)] map.fetch_many(executor),
-                    Self::Variant1(map) => #[allow(deprecated)] map.fetch_many(executor),
                 }
             }
             /// See [`sqlx::query::Map::fetch_all`]
@@ -68,11 +62,9 @@ fn dummy() {
                 DB: 'e,
                 O: 'e,
                 F0: 'e,
-                F1: 'e,
             {
                 match self {
                     Self::Variant0(map) => map.fetch_all(executor).await,
-                    Self::Variant1(map) => map.fetch_all(executor).await,
                 }
             }
             /// See [`sqlx::query::Map::fetch_one`]
@@ -83,11 +75,9 @@ fn dummy() {
                 DB: 'e,
                 O: 'e,
                 F0: 'e,
-                F1: 'e,
             {
                 match self {
                     Self::Variant0(map) => map.fetch_one(executor).await,
-                    Self::Variant1(map) => map.fetch_one(executor).await,
                 }
             }
             /// See [`sqlx::query::Map::fetch_optional`]
@@ -101,26 +91,15 @@ fn dummy() {
                 DB: 'e,
                 O: 'e,
                 F0: 'e,
-                F1: 'e,
             {
                 match self {
                     Self::Variant0(map) => map.fetch_optional(executor).await,
-                    Self::Variant1(map) => map.fetch_optional(executor).await,
                 }
             }
         }
         match ((),) {
-            () => {
-                ConditionalMap::Variant0(
-                    ::sqlx::query_as!(
-                        OutputType,
-                        "\n            SELECT column\n            FROM table\n            WHERE created_at > "
-                        + "$1" + "\n        ", created_at
-                    ),
-                )
-            }
             ((),) => {
-                ConditionalMap::Variant1(
+                ConditionalMap::Variant0(
                     ::sqlx::query_as!(
                         OutputType,
                         "\n            SELECT column\n            FROM table\n            WHERE created_at > "

--- a/core/src/snapshots/sqlx_conditional_queries_core__snapshot_tests__only_runtime_bound_parameters@Sqlite.snap
+++ b/core/src/snapshots/sqlx_conditional_queries_core__snapshot_tests__only_runtime_bound_parameters@Sqlite.snap
@@ -5,17 +5,15 @@ snapshot_kind: text
 ---
 fn dummy() {
     {
-        enum ConditionalMap<'q, DB: ::sqlx::Database, A, F0, F1> {
+        enum ConditionalMap<'q, DB: ::sqlx::Database, A, F0> {
             Variant0(::sqlx::query::Map<'q, DB, F0, A>),
-            Variant1(::sqlx::query::Map<'q, DB, F1, A>),
         }
-        impl<'q, DB, A, O, F0, F1> ConditionalMap<'q, DB, A, F0, F1>
+        impl<'q, DB, A, O, F0> ConditionalMap<'q, DB, A, F0>
         where
             DB: ::sqlx::Database,
             A: 'q + ::sqlx::IntoArguments<'q, DB> + ::std::marker::Send,
             O: ::std::marker::Unpin + ::std::marker::Send,
             F0: ::std::ops::FnMut(DB::Row) -> ::sqlx::Result<O> + ::std::marker::Send,
-            F1: ::std::ops::FnMut(DB::Row) -> ::sqlx::Result<O> + ::std::marker::Send,
         {
             /// See [`sqlx::query::Map::fetch`]
             pub fn fetch<'e, 'c: 'e, E>(
@@ -28,11 +26,9 @@ fn dummy() {
                 DB: 'e,
                 O: 'e,
                 F0: 'e,
-                F1: 'e,
             {
                 match self {
                     Self::Variant0(map) => map.fetch(executor),
-                    Self::Variant1(map) => map.fetch(executor),
                 }
             }
             /// See [`sqlx::query::Map::fetch_many`]
@@ -50,11 +46,9 @@ fn dummy() {
                 DB: 'e,
                 O: 'e,
                 F0: 'e,
-                F1: 'e,
             {
                 match self {
                     Self::Variant0(map) => #[allow(deprecated)] map.fetch_many(executor),
-                    Self::Variant1(map) => #[allow(deprecated)] map.fetch_many(executor),
                 }
             }
             /// See [`sqlx::query::Map::fetch_all`]
@@ -68,11 +62,9 @@ fn dummy() {
                 DB: 'e,
                 O: 'e,
                 F0: 'e,
-                F1: 'e,
             {
                 match self {
                     Self::Variant0(map) => map.fetch_all(executor).await,
-                    Self::Variant1(map) => map.fetch_all(executor).await,
                 }
             }
             /// See [`sqlx::query::Map::fetch_one`]
@@ -83,11 +75,9 @@ fn dummy() {
                 DB: 'e,
                 O: 'e,
                 F0: 'e,
-                F1: 'e,
             {
                 match self {
                     Self::Variant0(map) => map.fetch_one(executor).await,
-                    Self::Variant1(map) => map.fetch_one(executor).await,
                 }
             }
             /// See [`sqlx::query::Map::fetch_optional`]
@@ -101,26 +91,15 @@ fn dummy() {
                 DB: 'e,
                 O: 'e,
                 F0: 'e,
-                F1: 'e,
             {
                 match self {
                     Self::Variant0(map) => map.fetch_optional(executor).await,
-                    Self::Variant1(map) => map.fetch_optional(executor).await,
                 }
             }
         }
         match ((),) {
-            () => {
-                ConditionalMap::Variant0(
-                    ::sqlx::query_as!(
-                        OutputType,
-                        "\n            SELECT column\n            FROM table\n            WHERE created_at > "
-                        + "?" + "\n        ", created_at
-                    ),
-                )
-            }
             ((),) => {
-                ConditionalMap::Variant1(
+                ConditionalMap::Variant0(
                     ::sqlx::query_as!(
                         OutputType,
                         "\n            SELECT column\n            FROM table\n            WHERE created_at > "


### PR DESCRIPTION
This was accidentally broken when updating `itertools` to 0.13 as it changes the semantics of `multi_cartesian_product` where empty iterators always returns one empty vector.

Resolves #20.