### PR TITLE
Change `proc-macro-error` to `proc-macro-error2` to fix https://rustsec.org/advisories/RUSTSEC-2024-0370

### DIFF
--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -10,7 +10,7 @@ license = "MIT OR Apache-2.0"
 proc-macro = true
 
 [dependencies]
-proc-macro-error = "1.0.4"
+proc-macro-error2 = "2.0.1"
 proc-macro2 = "1.0.92"
 sqlx-conditional-queries-core = { path = "../core", version = "0.3" }
 

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -1,6 +1,6 @@
 #![doc = include_str!("../README.md")]
 
-use proc_macro_error::abort;
+use proc_macro_error2::abort;
 use sqlx_conditional_queries_core::{AnalyzeError, DatabaseType, Error, ExpandError};
 
 const DATABASE_TYPE: DatabaseType = if cfg!(feature = "postgres") {
@@ -14,7 +14,7 @@ const DATABASE_TYPE: DatabaseType = if cfg!(feature = "postgres") {
 };
 
 // The public docs for this macro live in the sql-conditional-queries crate.
-#[proc_macro_error::proc_macro_error]
+#[proc_macro_error2::proc_macro_error]
 #[proc_macro]
 pub fn conditional_query_as(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     let input: proc_macro2::TokenStream = input.into();


### PR DESCRIPTION
Hello.

[cargo-deny](https://github.com/EmbarkStudios/cargo-deny) detects the security issue in this crate.

- issue: https://rustsec.org/advisories/RUSTSEC-2024-0370

So I change `proc-macro-error` to `proc-macro-error2` to fix it. I chose `proc-macro-error2` because the interface is unchanged.

Please let me know if there is something I should do.

Thanks.