### PR TITLE
Catch compile-time binding duplicates and cycles

### DIFF
--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -44,6 +44,11 @@ pub fn conditional_query_as(input: proc_macro::TokenStream) -> proc_macro::Token
             AnalyzeError::DuplicatedCompileTimeBindingsFound { first: _, second } => {
                 abort!(second.span(), "found duplicate compile-time binding")
             }
+            AnalyzeError::CompileTimeBindingCycleDetected { root_ident, path } => abort!(
+                root_ident.span(),
+                "detected compile-time binding cycle: {}",
+                path
+            ),
         },
         Err(Error::ExpandError(err)) => match err {
             // TODO: Make this span point at the binding reference.  Requires https://github.com/rust-lang/rust/issues/54725

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -41,6 +41,9 @@ pub fn conditional_query_as(input: proc_macro::TokenStream) -> proc_macro::Token
                 names = names_span => "number of names: {}", names;
                 values = values_span => "number of values: {}", values;
             ),
+            AnalyzeError::DuplicatedCompileTimeBindingsFound { first: _, second } => {
+                abort!(second.span(), "found duplicate compile-time binding")
+            }
         },
         Err(Error::ExpandError(err)) => match err {
             // TODO: Make this span point at the binding reference.  Requires https://github.com/rust-lang/rust/issues/54725


### PR DESCRIPTION
Previously cycles would lead to an infinite loop which was reported here: https://github.com/kyrias/sqlx-conditional-queries/discussions/25#discussioncomment-11967591.