### PR TITLE
fix error caused by removing lifetime parameter `'q` from `IntoArguments` in sqlx version 0.9.0-alpha.1

### DIFF
--- a/core/src/codegen.rs
+++ b/core/src/codegen.rs
@@ -76,7 +76,7 @@ fn build_conditional_map(variant_count: usize) -> proc_macro2::TokenStream {
         impl<'q, DB, A, O, #(#function_params),*> ConditionalMap<'q, DB, A, #(#function_params),*>
         where
             DB: ::sqlx::Database,
-            A: 'q + ::sqlx::IntoArguments<'q, DB> + ::std::marker::Send,
+            A: 'q + ::sqlx::IntoArguments<DB> + ::std::marker::Send,
             O: ::std::marker::Unpin + ::std::marker::Send,
             #(
                 #function_params: ::std::ops::FnMut(DB::Row) -> ::sqlx::Result<O> + ::std::marker::Send,

--- a/core/src/snapshots/sqlx_conditional_queries_core__snapshot_tests__both_parameter_kinds@MySql.snap
+++ b/core/src/snapshots/sqlx_conditional_queries_core__snapshot_tests__both_parameter_kinds@MySql.snap
@@ -11,7 +11,7 @@ fn dummy() {
         impl<'q, DB, A, O, F0> ConditionalMap<'q, DB, A, F0>
         where
             DB: ::sqlx::Database,
-            A: 'q + ::sqlx::IntoArguments<'q, DB> + ::std::marker::Send,
+            A: 'q + ::sqlx::IntoArguments<DB> + ::std::marker::Send,
             O: ::std::marker::Unpin + ::std::marker::Send,
             F0: ::std::ops::FnMut(DB::Row) -> ::sqlx::Result<O> + ::std::marker::Send,
         {

--- a/core/src/snapshots/sqlx_conditional_queries_core__snapshot_tests__both_parameter_kinds@MySql_unchecked.snap
+++ b/core/src/snapshots/sqlx_conditional_queries_core__snapshot_tests__both_parameter_kinds@MySql_unchecked.snap
@@ -10,7 +10,7 @@ fn dummy() {
         impl<'q, DB, A, O, F0> ConditionalMap<'q, DB, A, F0>
         where
             DB: ::sqlx::Database,
-            A: 'q + ::sqlx::IntoArguments<'q, DB> + ::std::marker::Send,
+            A: 'q + ::sqlx::IntoArguments<DB> + ::std::marker::Send,
             O: ::std::marker::Unpin + ::std::marker::Send,
             F0: ::std::ops::FnMut(DB::Row) -> ::sqlx::Result<O> + ::std::marker::Send,
         {

--- a/core/src/snapshots/sqlx_conditional_queries_core__snapshot_tests__both_parameter_kinds@PostgreSql.snap
+++ b/core/src/snapshots/sqlx_conditional_queries_core__snapshot_tests__both_parameter_kinds@PostgreSql.snap
@@ -11,7 +11,7 @@ fn dummy() {
         impl<'q, DB, A, O, F0> ConditionalMap<'q, DB, A, F0>
         where
             DB: ::sqlx::Database,
-            A: 'q + ::sqlx::IntoArguments<'q, DB> + ::std::marker::Send,
+            A: 'q + ::sqlx::IntoArguments<DB> + ::std::marker::Send,
             O: ::std::marker::Unpin + ::std::marker::Send,
             F0: ::std::ops::FnMut(DB::Row) -> ::sqlx::Result<O> + ::std::marker::Send,
         {

--- a/core/src/snapshots/sqlx_conditional_queries_core__snapshot_tests__both_parameter_kinds@PostgreSql_unchecked.snap
+++ b/core/src/snapshots/sqlx_conditional_queries_core__snapshot_tests__both_parameter_kinds@PostgreSql_unchecked.snap
@@ -10,7 +10,7 @@ fn dummy() {
         impl<'q, DB, A, O, F0> ConditionalMap<'q, DB, A, F0>
         where
             DB: ::sqlx::Database,
-            A: 'q + ::sqlx::IntoArguments<'q, DB> + ::std::marker::Send,
+            A: 'q + ::sqlx::IntoArguments<DB> + ::std::marker::Send,
             O: ::std::marker::Unpin + ::std::marker::Send,
             F0: ::std::ops::FnMut(DB::Row) -> ::sqlx::Result<O> + ::std::marker::Send,
         {

--- a/core/src/snapshots/sqlx_conditional_queries_core__snapshot_tests__both_parameter_kinds@Sqlite.snap
+++ b/core/src/snapshots/sqlx_conditional_queries_core__snapshot_tests__both_parameter_kinds@Sqlite.snap
@@ -11,7 +11,7 @@ fn dummy() {
         impl<'q, DB, A, O, F0> ConditionalMap<'q, DB, A, F0>
         where
             DB: ::sqlx::Database,
-            A: 'q + ::sqlx::IntoArguments<'q, DB> + ::std::marker::Send,
+            A: 'q + ::sqlx::IntoArguments<DB> + ::std::marker::Send,
             O: ::std::marker::Unpin + ::std::marker::Send,
             F0: ::std::ops::FnMut(DB::Row) -> ::sqlx::Result<O> + ::std::marker::Send,
         {

--- a/core/src/snapshots/sqlx_conditional_queries_core__snapshot_tests__both_parameter_kinds@Sqlite_unchecked.snap
+++ b/core/src/snapshots/sqlx_conditional_queries_core__snapshot_tests__both_parameter_kinds@Sqlite_unchecked.snap
@@ -10,7 +10,7 @@ fn dummy() {
         impl<'q, DB, A, O, F0> ConditionalMap<'q, DB, A, F0>
         where
             DB: ::sqlx::Database,
-            A: 'q + ::sqlx::IntoArguments<'q, DB> + ::std::marker::Send,
+            A: 'q + ::sqlx::IntoArguments<DB> + ::std::marker::Send,
             O: ::std::marker::Unpin + ::std::marker::Send,
             F0: ::std::ops::FnMut(DB::Row) -> ::sqlx::Result<O> + ::std::marker::Send,
         {

--- a/core/src/snapshots/sqlx_conditional_queries_core__snapshot_tests__only_compile_time_bound_parameters@MySql.snap
+++ b/core/src/snapshots/sqlx_conditional_queries_core__snapshot_tests__only_compile_time_bound_parameters@MySql.snap
@@ -11,7 +11,7 @@ fn dummy() {
         impl<'q, DB, A, O, F0> ConditionalMap<'q, DB, A, F0>
         where
             DB: ::sqlx::Database,
-            A: 'q + ::sqlx::IntoArguments<'q, DB> + ::std::marker::Send,
+            A: 'q + ::sqlx::IntoArguments<DB> + ::std::marker::Send,
             O: ::std::marker::Unpin + ::std::marker::Send,
             F0: ::std::ops::FnMut(DB::Row) -> ::sqlx::Result<O> + ::std::marker::Send,
         {

--- a/core/src/snapshots/sqlx_conditional_queries_core__snapshot_tests__only_compile_time_bound_parameters@MySql_unchecked.snap
+++ b/core/src/snapshots/sqlx_conditional_queries_core__snapshot_tests__only_compile_time_bound_parameters@MySql_unchecked.snap
@@ -10,7 +10,7 @@ fn dummy() {
         impl<'q, DB, A, O, F0> ConditionalMap<'q, DB, A, F0>
         where
             DB: ::sqlx::Database,
-            A: 'q + ::sqlx::IntoArguments<'q, DB> + ::std::marker::Send,
+            A: 'q + ::sqlx::IntoArguments<DB> + ::std::marker::Send,
             O: ::std::marker::Unpin + ::std::marker::Send,
             F0: ::std::ops::FnMut(DB::Row) -> ::sqlx::Result<O> + ::std::marker::Send,
         {

--- a/core/src/snapshots/sqlx_conditional_queries_core__snapshot_tests__only_compile_time_bound_parameters@PostgreSql.snap
+++ b/core/src/snapshots/sqlx_conditional_queries_core__snapshot_tests__only_compile_time_bound_parameters@PostgreSql.snap
@@ -11,7 +11,7 @@ fn dummy() {
         impl<'q, DB, A, O, F0> ConditionalMap<'q, DB, A, F0>
         where
             DB: ::sqlx::Database,
-            A: 'q + ::sqlx::IntoArguments<'q, DB> + ::std::marker::Send,
+            A: 'q + ::sqlx::IntoArguments<DB> + ::std::marker::Send,
             O: ::std::marker::Unpin + ::std::marker::Send,
             F0: ::std::ops::FnMut(DB::Row) -> ::sqlx::Result<O> + ::std::marker::Send,
         {

--- a/core/src/snapshots/sqlx_conditional_queries_core__snapshot_tests__only_compile_time_bound_parameters@PostgreSql_unchecked.snap
+++ b/core/src/snapshots/sqlx_conditional_queries_core__snapshot_tests__only_compile_time_bound_parameters@PostgreSql_unchecked.snap
@@ -10,7 +10,7 @@ fn dummy() {
         impl<'q, DB, A, O, F0> ConditionalMap<'q, DB, A, F0>
         where
             DB: ::sqlx::Database,
-            A: 'q + ::sqlx::IntoArguments<'q, DB> + ::std::marker::Send,
+            A: 'q + ::sqlx::IntoArguments<DB> + ::std::marker::Send,
             O: ::std::marker::Unpin + ::std::marker::Send,
             F0: ::std::ops::FnMut(DB::Row) -> ::sqlx::Result<O> + ::std::marker::Send,
         {

--- a/core/src/snapshots/sqlx_conditional_queries_core__snapshot_tests__only_compile_time_bound_parameters@Sqlite.snap
+++ b/core/src/snapshots/sqlx_conditional_queries_core__snapshot_tests__only_compile_time_bound_parameters@Sqlite.snap
@@ -11,7 +11,7 @@ fn dummy() {
         impl<'q, DB, A, O, F0> ConditionalMap<'q, DB, A, F0>
         where
             DB: ::sqlx::Database,
-            A: 'q + ::sqlx::IntoArguments<'q, DB> + ::std::marker::Send,
+            A: 'q + ::sqlx::IntoArguments<DB> + ::std::marker::Send,
             O: ::std::marker::Unpin + ::std::marker::Send,
             F0: ::std::ops::FnMut(DB::Row) -> ::sqlx::Result<O> + ::std::marker::Send,
         {

--- a/core/src/snapshots/sqlx_conditional_queries_core__snapshot_tests__only_compile_time_bound_parameters@Sqlite_unchecked.snap
+++ b/core/src/snapshots/sqlx_conditional_queries_core__snapshot_tests__only_compile_time_bound_parameters@Sqlite_unchecked.snap
@@ -10,7 +10,7 @@ fn dummy() {
         impl<'q, DB, A, O, F0> ConditionalMap<'q, DB, A, F0>
         where
             DB: ::sqlx::Database,
-            A: 'q + ::sqlx::IntoArguments<'q, DB> + ::std::marker::Send,
+            A: 'q + ::sqlx::IntoArguments<DB> + ::std::marker::Send,
             O: ::std::marker::Unpin + ::std::marker::Send,
             F0: ::std::ops::FnMut(DB::Row) -> ::sqlx::Result<O> + ::std::marker::Send,
         {

--- a/core/src/snapshots/sqlx_conditional_queries_core__snapshot_tests__only_runtime_bound_parameters@MySql.snap
+++ b/core/src/snapshots/sqlx_conditional_queries_core__snapshot_tests__only_runtime_bound_parameters@MySql.snap
@@ -11,7 +11,7 @@ fn dummy() {
         impl<'q, DB, A, O, F0> ConditionalMap<'q, DB, A, F0>
         where
             DB: ::sqlx::Database,
-            A: 'q + ::sqlx::IntoArguments<'q, DB> + ::std::marker::Send,
+            A: 'q + ::sqlx::IntoArguments<DB> + ::std::marker::Send,
             O: ::std::marker::Unpin + ::std::marker::Send,
             F0: ::std::ops::FnMut(DB::Row) -> ::sqlx::Result<O> + ::std::marker::Send,
         {

--- a/core/src/snapshots/sqlx_conditional_queries_core__snapshot_tests__only_runtime_bound_parameters@MySql_unchecked.snap
+++ b/core/src/snapshots/sqlx_conditional_queries_core__snapshot_tests__only_runtime_bound_parameters@MySql_unchecked.snap
@@ -10,7 +10,7 @@ fn dummy() {
         impl<'q, DB, A, O, F0> ConditionalMap<'q, DB, A, F0>
         where
             DB: ::sqlx::Database,
-            A: 'q + ::sqlx::IntoArguments<'q, DB> + ::std::marker::Send,
+            A: 'q + ::sqlx::IntoArguments<DB> + ::std::marker::Send,
             O: ::std::marker::Unpin + ::std::marker::Send,
             F0: ::std::ops::FnMut(DB::Row) -> ::sqlx::Result<O> + ::std::marker::Send,
         {

--- a/core/src/snapshots/sqlx_conditional_queries_core__snapshot_tests__only_runtime_bound_parameters@PostgreSql.snap
+++ b/core/src/snapshots/sqlx_conditional_queries_core__snapshot_tests__only_runtime_bound_parameters@PostgreSql.snap
@@ -11,7 +11,7 @@ fn dummy() {
         impl<'q, DB, A, O, F0> ConditionalMap<'q, DB, A, F0>
         where
             DB: ::sqlx::Database,
-            A: 'q + ::sqlx::IntoArguments<'q, DB> + ::std::marker::Send,
+            A: 'q + ::sqlx::IntoArguments<DB> + ::std::marker::Send,
             O: ::std::marker::Unpin + ::std::marker::Send,
             F0: ::std::ops::FnMut(DB::Row) -> ::sqlx::Result<O> + ::std::marker::Send,
         {

--- a/core/src/snapshots/sqlx_conditional_queries_core__snapshot_tests__only_runtime_bound_parameters@PostgreSql_unchecked.snap
+++ b/core/src/snapshots/sqlx_conditional_queries_core__snapshot_tests__only_runtime_bound_parameters@PostgreSql_unchecked.snap
@@ -10,7 +10,7 @@ fn dummy() {
         impl<'q, DB, A, O, F0> ConditionalMap<'q, DB, A, F0>
         where
             DB: ::sqlx::Database,
-            A: 'q + ::sqlx::IntoArguments<'q, DB> + ::std::marker::Send,
+            A: 'q + ::sqlx::IntoArguments<DB> + ::std::marker::Send,
             O: ::std::marker::Unpin + ::std::marker::Send,
             F0: ::std::ops::FnMut(DB::Row) -> ::sqlx::Result<O> + ::std::marker::Send,
         {

--- a/core/src/snapshots/sqlx_conditional_queries_core__snapshot_tests__only_runtime_bound_parameters@Sqlite.snap
+++ b/core/src/snapshots/sqlx_conditional_queries_core__snapshot_tests__only_runtime_bound_parameters@Sqlite.snap
@@ -11,7 +11,7 @@ fn dummy() {
         impl<'q, DB, A, O, F0> ConditionalMap<'q, DB, A, F0>
         where
             DB: ::sqlx::Database,
-            A: 'q + ::sqlx::IntoArguments<'q, DB> + ::std::marker::Send,
+            A: 'q + ::sqlx::IntoArguments<DB> + ::std::marker::Send,
             O: ::std::marker::Unpin + ::std::marker::Send,
             F0: ::std::ops::FnMut(DB::Row) -> ::sqlx::Result<O> + ::std::marker::Send,
         {

--- a/core/src/snapshots/sqlx_conditional_queries_core__snapshot_tests__only_runtime_bound_parameters@Sqlite_unchecked.snap
+++ b/core/src/snapshots/sqlx_conditional_queries_core__snapshot_tests__only_runtime_bound_parameters@Sqlite_unchecked.snap
@@ -10,7 +10,7 @@ fn dummy() {
         impl<'q, DB, A, O, F0> ConditionalMap<'q, DB, A, F0>
         where
             DB: ::sqlx::Database,
-            A: 'q + ::sqlx::IntoArguments<'q, DB> + ::std::marker::Send,
+            A: 'q + ::sqlx::IntoArguments<DB> + ::std::marker::Send,
             O: ::std::marker::Unpin + ::std::marker::Send,
             F0: ::std::ops::FnMut(DB::Row) -> ::sqlx::Result<O> + ::std::marker::Send,
         {


### PR DESCRIPTION
this should probably only be merged once stable sqlx 0.9.0 is released